### PR TITLE
Fix: Get last chat on filter conversation

### DIFF
--- a/client/src/components/messages/Messages.jsx
+++ b/client/src/components/messages/Messages.jsx
@@ -29,6 +29,7 @@ function Messages() {
         ))}
       {!loading && messages.length === 0 && (
         <div className="text-center opacity-50 text-white">
+          <br />
           Send a message to start a conversation
         </div>
       )}

--- a/client/src/components/sidebar/Conversation.jsx
+++ b/client/src/components/sidebar/Conversation.jsx
@@ -3,7 +3,7 @@ import { useSocketContext } from "../../context/SocketContext";
 import { extractTime } from "../../utils/extractTime";
 
 function Conversation({ conversation, lastIdx, userLastChat, fetching }) {
-  const { selectedConversation, setSelectedConversation, loading } = useConversation();
+  const { selectedConversation, setSelectedConversation } = useConversation();
   const isSelected = selectedConversation?._id === conversation._id;
 
   const { onlineUsers } = useSocketContext(); /* Get online users */
@@ -13,6 +13,7 @@ function Conversation({ conversation, lastIdx, userLastChat, fetching }) {
   const formattedDateTime = extractTime(
     userLastChat?.updatedAt || userLastChat?.createdAt
   );
+  
 
   return (
     <>
@@ -34,10 +35,10 @@ function Conversation({ conversation, lastIdx, userLastChat, fetching }) {
               {conversation.fullName}
             </p>
             <div className="md:flex justify-between hidden">
-              {userLastChat?.message ? (
+              {userLastChat?.last_chat ? (
                 <>
                   <p className="text-gray-400 text-xs 2xl:text-md italic">
-                    {fetching ? "..." : userLastChat.message}
+                    {fetching ? "..." : userLastChat.last_chat}
                   </p>
                   <p className="text-gray-400 text-xs 2xl:text-md italic">
                     {fetching ? "" : formattedDateTime}

--- a/client/src/components/sidebar/Conversations.jsx
+++ b/client/src/components/sidebar/Conversations.jsx
@@ -8,20 +8,33 @@ function Conversations() {
   const [allReceivers, setAllReceivers] = useState([]);
   const { search, setReceiver } = useConversation();
   const { loading, conversations } = useGetConversations();
-  const { userLastChat, fetching } = useGetLastChat();
-  
+  const { userLastChat, fetching, arrayLastChat } = useGetLastChat();
+
   const getReceiver = async () => {
     conversations.map((conversation) => {
       setAllReceivers((prev) => [...prev, conversation._id]);
-    })
+    });
+  };
 
+  const getIndexLastChat = (conversation) => {
+    let obj;
+    userLastChat.map((user) => {
+      if (
+        user?.senderId === conversation._id ||
+        user?.receiverId === conversation._id
+      )
+        obj = user;
+    });
+
+    const index = arrayLastChat.findIndex((data) => data === obj?.last_chat);
+    return userLastChat[index];
   };
 
   useEffect(() => {
     getReceiver();
     setReceiver(allReceivers);
-  }, [conversations]);
-  
+  }, [conversations, search]);
+
   return (
     <div className="py-2 flex flex-col overflow-auto">
       {search
@@ -34,10 +47,11 @@ function Conversations() {
                 key={conversation._id}
                 conversation={conversation}
                 lastIdx={idx === conversations.length - 1}
+                userLastChat={getIndexLastChat(conversation)}
+                fetching={fetching}
               />
             ))
         : conversations.map((conversation, idx) => (
-
             <Conversation
               key={conversation._id}
               conversation={conversation}
@@ -45,7 +59,7 @@ function Conversations() {
               userLastChat={userLastChat[idx]}
               fetching={fetching}
             />
-            ))}
+          ))}
       {loading ? <span className="loading loading-spinner"></span> : null}
     </div>
   );

--- a/client/src/hooks/useGetLastChat.js
+++ b/client/src/hooks/useGetLastChat.js
@@ -11,26 +11,42 @@ import useConversation from "../zustand/useConversation";
  */
 function useGetLastChat() {
   const [fetching, setFetching] = useState(false);
-  const { userLastChat, setUserLastChat, receiver } = useConversation();
+  const { userLastChat, setUserLastChat, receiver, setArrayLastChat, arrayLastChat } = useConversation();
 
   useEffect(() => {
     const getLastChat = async () => {
       setFetching(true);
       try {
         let messages = [];
+        let arrMessages = [];
 
         for(let i = 0; i < receiver.length; i++) {
           const res = await fetch(`/api/messages/${receiver[i]}`);
           const data = await res.json();
 
           if (data.error) throw new Error(data.error); /* Handle Error */
+
+          
           if(data.length === 0){
-            messages.push("");
+            /* If no message, push empty object */
+            messages.push({
+              last_chat: "",
+            });
+            arrMessages.push("");
           }else{
-            messages.push(data[data.length - 1]);
+            /* If message, push last message */
+            messages.push({
+              senderId: data[data.length - 1].senderId,
+              receiverId: data[data.length - 1].receiverId,
+              last_chat: data[data.length - 1].message,
+              createdAt: data[data.length - 1].createdAt,
+              updatedAt: data[data.length - 1].updatedAt
+            });
+            arrMessages.push(data[data.length - 1].message);
           }
         };
-        setUserLastChat(messages);
+        setUserLastChat(messages); /* Set User Last Chat object */
+        setArrayLastChat(arrMessages); /* Set Array Last Chat */
       } catch (error) {
         toast.error(error.message);
       } finally {
@@ -43,7 +59,7 @@ function useGetLastChat() {
     getLastChat();
   }, [receiver, setUserLastChat]);
 
-  return { fetching, userLastChat };
+  return { fetching, userLastChat, arrayLastChat };
 }
 
 export default useGetLastChat;

--- a/client/src/zustand/useConversation.js
+++ b/client/src/zustand/useConversation.js
@@ -12,6 +12,8 @@ const useConversation = create((set) => ({
   setReceiver: (receiver) => set({ receiver }),
   userLastChat: [],
   setUserLastChat: (userLastChat) => set({ userLastChat }),
+  arrayLastChat: [],
+  setArrayLastChat: (arrayLastChat) => set({ arrayLastChat }),
 }));
 
 export default useConversation;


### PR DESCRIPTION
- [x] Fetch the conversation last chat when filtering search input.
- [x] Change user last chat output from array to array of objects. 
- [x] Added variable to zustand. 